### PR TITLE
Fix an issue with opening tests being denied

### DIFF
--- a/src/tests/test_sessions/requests.rs
+++ b/src/tests/test_sessions/requests.rs
@@ -178,7 +178,7 @@ pub(crate) fn open(
             let existing_open_registrations =
                 test_session_registrations_schema::table
                     .filter(
-                        test_session_registrations_schema::id.eq(test_session_id).and(
+                        test_session_registrations_schema::test_session_id.eq(test_session_id).and(
                         test_session_registrations_schema::taker_id
                             .eq(user_id)
                             .and(


### PR DESCRIPTION
Logic error that would only allow registrations with the same id as the
test session